### PR TITLE
chore: Update deploy_build_artifact.yaml permissions and artifact path

### DIFF
--- a/.github/workflows/deploy_build_artifact.yaml
+++ b/.github/workflows/deploy_build_artifact.yaml
@@ -1,5 +1,6 @@
 name: build artifact
 on: 
+  workflow_dispatch:
   workflow_call:
     outputs:
       artifact-url:
@@ -82,12 +83,12 @@ jobs:
           compression-level: 0 # no compression
           if-no-files-found: error
           name: ${{ steps.Build.outputs.artifact_name }}
-          path: "dist/*,${{ steps.attest-artifacts.outputs.bundle-path }}/*"
+          path: dist/*
 
       - name: publish release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: dist/*
+          artifacts: "dist/*,${{ steps.attest-artifacts.outputs.bundle-path }}/*"
           tag: ${{ steps.Build.outputs.version }}
           allowUpdates: true
           artifactErrorsFailBuild: true


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the deploy_build_artifact.yaml workflow by adding a 'workflow_dispatch' trigger, adjusting the artifact path in the 'upload-artifact' step, and modifying the 'publish release' step to include the bundle path in the artifacts.

- **CI**:
    - Added 'workflow_dispatch' trigger to the deploy_build_artifact.yaml workflow.
- **Deployment**:
    - Updated artifact path in the 'upload-artifact' step to only include 'dist/*'.
    - Modified 'publish release' step to include the bundle path in the artifacts.

<!-- Generated by sourcery-ai[bot]: end summary -->