### PR TITLE
chore: Update deploy_build_artifact.yaml permissions and artifact path

### DIFF
--- a/.github/workflows/deploy_build_artifact.yaml
+++ b/.github/workflows/deploy_build_artifact.yaml
@@ -1,5 +1,6 @@
 name: build artifact
 on: 
+  workflow_dispatch:
   workflow_call:
     outputs:
       artifact-url:
@@ -82,12 +83,12 @@ jobs:
           compression-level: 0 # no compression
           if-no-files-found: error
           name: ${{ steps.Build.outputs.artifact_name }}
-          path: "dist/*,${{ steps.attest-artifacts.outputs.bundle-path }}/*"
+          path: dist/*
 
       - name: publish release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: dist/*
+          artifacts: "dist/*,${{ steps.attest-artifacts.outputs.bundle-path }}/*"
           tag: ${{ steps.Build.outputs.version }}
           allowUpdates: true
           artifactErrorsFailBuild: true


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update deploy_build_artifact.yaml to include a 'workflow_dispatch' trigger and modify artifact paths for build and release steps.

CI:
- Add 'workflow_dispatch' trigger to the deploy_build_artifact.yaml workflow.

Deployment:
- Update artifact path in the deploy_build_artifact.yaml workflow to 'dist/*'.
- Change the 'publish release' step to use the updated artifact path 'dist/*,${{ steps.attest-artifacts.outputs.bundle-path }}/*'.

<!-- Generated by sourcery-ai[bot]: end summary -->